### PR TITLE
Deterministic private key

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,3 +206,14 @@ duration     attempts private-key                                               
     export LC_ALL=C.UTF-8
     export LANG=C.UTF-8
     ```
+
+3. `pytest` is failing.
+
+   From https://stackoverflow.com/a/54597424:
+
+   > 1. activate your venv : source venv/bin/activate
+   > 2. install pytest : pip install pytest
+   > 3. re-activate your venv: deactivate && source venv/bin/activate
+   >
+   > The reason is that the path to pytest is set by the sourceing the activate file only after pytest is actually installed in the venv.
+   > You can't set the path to something before it is installed.

--- a/brute_force_app.py
+++ b/brute_force_app.py
@@ -51,6 +51,32 @@ class SigningKey(ecdsa.SigningKey):
     def hexlify_public(self):
         return self._hexlify(self.get_verifying_key().to_string())
 
+    @staticmethod
+    def public_address(private_key_str=None):
+        if private_key_str is not None:
+            import binascii
+            _p = private_key_str.lower()
+            _p = bytes(_p, 'utf-8')
+            _p = binascii.unhexlify(_p)
+            priv = SigningKey.from_string(_p, curve=ecdsa.SECP256k1)
+        else:
+            priv = SigningKey.generate(curve=ecdsa.SECP256k1)
+
+        pub = priv.get_verifying_key().to_string()
+        keccak = sha3.keccak_256()
+        keccak.update(pub)
+        address = keccak.hexdigest()[24:]
+        return priv.hexlify_private(), address
+
+
+def test_get_public_address():
+    sample_data = {
+        '66873FDEF9BEC6F5D39D840CD7DDE4CA94270D3BF3AA9C5B372CDB5E07EADEFA': 'Dd36d7b54d489f4c2c0A7Ad57fc7180bAdD60072',
+        'C45910361C0BD601F8F1D93F53882EC7989160B97B095F3F4DA46F8206455761': '5EF98356CDd925203b5aeD05045dfd81A7667619',
+        }
+    for private_key, eth_address in sample_data.items():
+        assert (private_key.lower(), eth_address.lower()) == SigningKey.public_address(private_key)
+
 
 def GetResourcePath(*path_fragments):
     """Return a path to a local resource (relative to this script)"""
@@ -180,13 +206,8 @@ def main(fps, timeout, max_guesses, addresses, port, no_port, strategy, quiet, e
 
             varz.num_tries += 1
 
-            priv = SigningKey.generate(curve=ecdsa.SECP256k1)
-            pub = priv.get_verifying_key().to_string()
-
-            keccak = sha3.keccak_256()
-            keccak.update(pub)
-            address = keccak.hexdigest()[24:]
-
+            # calculate a public eth address from a random private key
+            private_key_hex, address = SigningKey.public_address() 
             current = target_addresses.FindClosestMatch(address)
             strength, _, closest = current
 
@@ -194,7 +215,7 @@ def main(fps, timeout, max_guesses, addresses, port, no_port, strategy, quiet, e
                 if not quiet:
                     EchoLine(now - start_time,
                              varz.num_tries,
-                             priv.hexlify_private(),
+                             private_key_hex,
                              strength,
                              address,
                              closest)
@@ -206,7 +227,7 @@ def main(fps, timeout, max_guesses, addresses, port, no_port, strategy, quiet, e
                 if not quiet:
                     EchoLine(now - start_time,
                              varz.num_tries,
-                             priv.hexlify_private(),
+                             private_key_hex,
                              strength,
                              address,
                              closest,
@@ -214,8 +235,7 @@ def main(fps, timeout, max_guesses, addresses, port, no_port, strategy, quiet, e
                 varz.best_score = current
 
                 best_guess_report = {
-                    'private-key': priv.hexlify_private(),
-                    'public-key': priv.hexlify_public(),
+                    'private-key': private_key_hex,
                     'address': address,
                 }
                 if closest is not None:

--- a/brute_force_app.py
+++ b/brute_force_app.py
@@ -26,13 +26,6 @@ ETH_ADDRESS_LENGTH = 40
 
 def calc_strength(guess, target) -> int:
     """Calculate the strength of an address guess"""
-    for matching_digits, (lhs, rhs) in enumerate(zip(guess, target)):
-        if lhs != rhs:
-            return matching_digits
-
-
-def calc_strength(guess, target) -> int:
-    """Calculate the strength of an address guess"""
     strength = 0
     for lhs, rhs in zip(guess, target):
         strength += 1 if lhs == rhs else 0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@ ecdsa
 requests
 pysha3>=1.0.2
 pyyaml
+pytest
 sortedcollections


### PR DESCRIPTION
Usage: brute_force_app.py [OPTIONS] [ETH_ADDRESS]...

Options:
  --quiet                         Skip the animation
  --strategy [trie|nearest|bisect]
                                  Choose a lookup strategy for eth addresses
  --no-port                       Disable monitoring port.
  --port INTEGER                  Monitoring port for runtime metrics.
  --addresses FILENAME            Filename for yaml file containing target
                                  addresses.
  --max-guesses INTEGER           If set to a positive integer, stop trying
                                  after this many attempts.
  --timeout INTEGER               If set to a positive integer, stop trying
                                  after this many seconds.
  --fps INTEGER                   Use this many frames per second when showing
                                  guesses.  Use non-positive number to go as
                                  fast as possible.
  --help                          Show this message and exit.